### PR TITLE
Update guzzle dependency and version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fontis/auspost-api-php",
+    "name": "proxiblue/auspost-api-php",
     "description": "Auspost API Client Library for PHP",
     "license": "LGPL-3.0",
     "authors":[

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "guzzle/guzzle": "*"
+        "guzzlehttp/guzzle": "3.8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*"


### PR DESCRIPTION
Guzzle/guzzle is depricated. it is now guzzlehttp/guzzle - additionally seems last working compatible version is 3.8.1 ?
