### PR TITLE
Allow weights to use decimals

### DIFF
--- a/src/Auspost/Postage/service.json
+++ b/src/Auspost/Postage/service.json
@@ -53,7 +53,7 @@
                 },
                 "weight": {
                     "required": true,
-                    "type": "integer",
+                    "type": "number",
                     "location": "query"
                 }
             }
@@ -89,7 +89,7 @@
                 },
                 "weight": {
                     "required": true,
-                    "type": "integer",
+                    "type": "number",
                     "location": "query"
                 }
             }
@@ -105,7 +105,7 @@
                 },
                 "weight": {
                     "required": false,
-                    "type": "integer",
+                    "type": "number",
                     "location": "query"
                 }
             }
@@ -121,7 +121,7 @@
                 },
                 "weight": {
                     "required": true,
-                    "type": "integer",
+                    "type": "number",
                     "location": "query"
                 }
             }
@@ -159,7 +159,7 @@
                 },
                 "weight": {
                     "required": true,
-                    "type": "integer",
+                    "type": "number",
                     "location": "query"
                 },
                 "option_code": {
@@ -210,7 +210,7 @@
                 },
                 "weight": {
                     "required": true,
-                    "type": "integer",
+                    "type": "number",
                     "location": "query"
                 },
                 "service_code": {
@@ -251,7 +251,7 @@
                 },
                 "weight": {
                     "required": false,
-                    "type": "integer",
+                    "type": "number",
                     "location": "query"
                 }
             }
@@ -267,7 +267,7 @@
                 },
                 "weight": {
                     "required": true,
-                    "type": "integer",
+                    "type": "number",
                     "location": "query"
                 },
                 "service_code": {


### PR DESCRIPTION
Allow weights used in API requests to be decimals (Australia Post supports this).
